### PR TITLE
Replace TargetInfo with ReadOnlyTargetRules in build scripts

### DIFF
--- a/Plugins/Effekseer/Source/Effekseer/Effekseer.Build.cs
+++ b/Plugins/Effekseer/Source/Effekseer/Effekseer.Build.cs
@@ -4,7 +4,8 @@ namespace UnrealBuildTool.Rules
 {
 	public class Effekseer : ModuleRules
 	{
-		public Effekseer(TargetInfo Target)
+		public Effekseer(ReadOnlyTargetRules Target)
+			: base(Target)
 		{
 			PublicIncludePaths.AddRange(
 				new string[] {

--- a/Plugins/Effekseer/Source/EffekseerEd/EffekseerEd.Build.cs
+++ b/Plugins/Effekseer/Source/EffekseerEd/EffekseerEd.Build.cs
@@ -4,7 +4,8 @@ namespace UnrealBuildTool.Rules
 {
 	public class EffekseerEd : ModuleRules
 	{
-		public EffekseerEd(TargetInfo Target)
+		public EffekseerEd(ReadOnlyTargetRules Target)
+			: base(Target)
 		{
 			PublicIncludePaths.AddRange(
 				new string[] {

--- a/Source/EffekseerForUE4/EffekseerForUE4.Build.cs
+++ b/Source/EffekseerForUE4/EffekseerForUE4.Build.cs
@@ -4,7 +4,8 @@ using UnrealBuildTool;
 
 public class EffekseerForUE4 : ModuleRules
 {
-	public EffekseerForUE4(TargetInfo Target)
+	public EffekseerForUE4(ReadOnlyTargetRules Target)
+		: base(Target)
 	{
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
 


### PR DESCRIPTION
The Build script convention has changed since UE 4.16, and UnrealBuildTool complains as follows when building the plugin and/or sample script:

```
warning : Module constructors should take a ReadOnlyTargetRules argument (rather than a TargetInfo argument) and pass it to the base class constructor from 4.15 onwards. Please update the method signature.
```

This patch fixes this issue and makes both the plugin and example project to compile without warnings from UnrealBuildTool in and after UE 4.16.
